### PR TITLE
Add github action runners

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,89 @@
+name: Cross compile for Windows
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MinGW
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-mingw-w64-i686-win32
+
+      - name: Load Pidgin from cache
+        id: pidgin-cache
+        uses: actions/cache@v4
+        with:
+          path: pidgin
+          key: pidgin-2.14.1
+      
+      - name: Download Pidgin
+        if: steps.pidgin-cache.outputs.cache-hit != 'true'
+        run: |
+          curl --http1.1 -L https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.1/pidgin-2.14.1.tar.bz2/download -o pidgin.tar.bz2
+          tar -xf pidgin.tar.bz2
+          mv pidgin-2.14.1 pidgin
+          curl --http1.1 -L https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.1/pidgin-2.14.1-win32-bin.zip/download -o pidgin-win32bin.zip
+          unzip pidgin-win32bin.zip
+          cp pidgin-2.14.1-win32bin/libpurple.dll pidgin/libpurple/
+      
+      - name: Load Win32 deps from cache
+        id: win32-cache
+        uses: actions/cache@v4
+        with:
+          path: win32-dev
+          key: win32-dev
+      
+      - name: Setup WinPidgin build
+        if: steps.win32-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir win32-dev
+          curl --http1.1 -L https://download.gnome.org/binaries/win32/glib/2.28/glib-dev_2.28.8-1_win32.zip -o glib-dev.zip
+          unzip glib-dev.zip -d win32-dev/glib-2.28.8
+          curl --http1.1 -L https://download.gnome.org/binaries/win32/dependencies/gettext-runtime-dev_0.18.1.1-2_win32.zip -o gettext-runtime.zip
+          unzip gettext-runtime.zip -d win32-dev/glib-2.28.8
+          curl --http1.1 -L https://download.gnome.org/binaries/win32/dependencies/zlib-dev_1.2.5-2_win32.zip -o zlib-dev.zip
+          unzip zlib-dev.zip -d win32-dev/glib-2.28.8
+
+          ls win32-dev/
+
+      - name: make
+        run: |
+          export CC=i686-w64-mingw32-gcc
+          export PIDGIN_TREE_TOP=pidgin
+          export GTK_TOP=win32-dev/glib-2.28.8
+          make -f Makefile.mingw
+
+      - name: archive
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with: 
+            name: plugin 
+            path: lib*.dll
+
+      - name: release
+        if: ${{ !env.ACT }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: lib*.dll
+          tag: nightly-${{ github.sha }}
+          name: Nightly ${{ github.sha }}
+          allowUpdates: true
+          makeLatest: true
+
+      - name: attest
+        if: ${{ !env.ACT }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: lib*.dll

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,50 @@
+name: Linux
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: install deps
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libjson-glib-dev gettext
+          # We only need these to build, not to run.  Skip the dependency check.
+          sudo apt download libpurple0 libpurple-dev
+          sudo dpkg --force-depends -i libpurple0*.deb libpurple-dev*.deb
+      - name: make
+        run: make
+
+      - name: archive
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with: 
+            name: plugin 
+            path: lib*.so
+
+      - name: release
+        if: ${{ !env.ACT }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: lib*.so
+          tag: nightly-${{ github.sha }}
+          name: Nightly ${{ github.sha }}
+          allowUpdates: true
+          makeLatest: true
+
+      - name: attest
+        if: ${{ !env.ACT }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: lib*.so

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -4,15 +4,15 @@
 
 include ./nanopb/extra/nanopb.mk
 
-CC := gcc
+CC ?= gcc
 C_FLAGS = -Wall -Werror -g -O2
 
 
 
 #  PIDGIN_TREE_TOP := ../pidgin-release-2.x.y
-PIDGIN_TREE_TOP := ../pidgin-v2.14.13
-GTK_TOP := ../win32-dev/gtk_2_0-2.14
-PURPLE_TOP := $(PIDGIN_TREE_TOP)/libpurple
+PIDGIN_TREE_TOP ?= ../pidgin-v2.14.13
+GTK_TOP ?= ../win32-dev/gtk_2_0-2.14
+PURPLE_TOP ?= $(PIDGIN_TREE_TOP)/libpurple
 
 ##
 ## INCLUDE PATHS

--- a/meshtastic.c
+++ b/meshtastic.c
@@ -20,6 +20,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #else
+#include <winsock2.h>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Great to see another Pidgin plugin dev on the scene! 🎉 

This PR adds support for building a 64bit linux .so and 32bit windows .dll using GitHub Action runners

It needed a couple of tweaks to build:
* Allow overriding the Makefile variables from env, in the Windows makefile
* Fix for a compiler error "Include winsock2.h before including windows.h" that must only be on newer versions of gcc?